### PR TITLE
FIx of service template and deploy-certs order

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,15 +19,15 @@
     - exporter_exporter_configure
     - exporter_exporter_run
 
-- import_tasks:  deploy-certs.yml
-  become: true
-  when: exporter_exporter_ca_file | trim != '' and exporter_exporter_cert_file | trim != '' and exporter_exporter_key_file | trim != ''
-  tags:
-    - exporter_exporter_install
-  
 - import_tasks: install.yml
   become: true
   when: (not __exporter_exporter_is_installed.stat.exists) or (__exporter_exporter_current_version_output.stderr_lines[0].split(" ")[2] != exporter_exporter_version)
+  tags:
+    - exporter_exporter_install
+
+- import_tasks: deploy-certs.yml
+  become: true
+  when: exporter_exporter_ca_file | trim != '' and exporter_exporter_cert_file | trim != '' and exporter_exporter_key_file | trim != ''
   tags:
     - exporter_exporter_install
 

--- a/templates/exporter_exporter.service.j2
+++ b/templates/exporter_exporter.service.j2
@@ -3,7 +3,6 @@
 [Unit]
 Description=Prometheus Exporter Exporter
 After=network-online.target
-StartLimitInterval=0
 
 [Service]
 Type=simple
@@ -12,41 +11,40 @@ Group={{ exporter_exporter_system_group }}
 ExecStart=/usr/local/bin/exporter_exporter \
 {%   if exporter_exporter_web_listen_address|length %}
     -web.listen-address {{ exporter_exporter_web_listen_address }} \
-{%   else -%}
+{%   else %}
     -web.listen-address=\
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_config_file|length %}
     -config.file {{ exporter_exporter_config_file }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_bearer_token|length %}
     -web.bearer.token {{ exporter_exporter_web_bearer_token }} \
 {%   elif exporter_exporter_web_bearer_token_file|length %}
     -web.bearer.token-file {{ exporter_exporter_web_bearer_token_file }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_proxy_path|length %}
     -web.proxy-path {{ exporter_exporter_web_proxy_path }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_telemetry_path|length %}
     -web.telemetry-path {{ exporter_exporter_web_telemetry_path }} \
-{%   endif -%}
-
+{%   endif %}
 {%   if exporter_exporter_web_tls_ca|length %}
     -web.tls.ca {{ exporter_exporter_web_tls_ca }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_tls_cert|length %}
     -web.tls.cert {{ exporter_exporter_web_tls_cert }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_tls_key|length %}
     -web.tls.key  {{ exporter_exporter_web_tls_key }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_tls_listen_address|length %}
     -web.tls.listen-address {{ exporter_exporter_web_tls_listen_address }} \
-{%   endif -%}
+{%   endif %}
 {%   if exporter_exporter_web_tls_verify %}
     -web.tls.verify \
-{%   endif -%}
+{%   endif %}
 
-
+StartLimitInterval=0
 SyslogIdentifier=exporter_exporter
 Restart=always
 RestartSec=1


### PR DESCRIPTION
This PR fixes:
1. service template. `-%}` doesn't honor newlines, so `ExecStart` might be populated with `SyslogIdentifier` (no newline after `\`). Tested with ansible 2.9.6. `StartLimitInterval` should be in `[Service]`
2. deploy-certs order. Certs should be deployed after install (after creating user and group) to set proper owner/group if needed.